### PR TITLE
FIX: buildDependencyAssets() stack overflow

### DIFF
--- a/lib/DependencyGraph.js
+++ b/lib/DependencyGraph.js
@@ -16,7 +16,7 @@ class DependencyGraph extends DepGraph {
       const entryAssetPath = entryAsset.parentBundle.name;
 
       this.addNode(entryAssetPath);
-      this.buildDependencyAssets(entryAsset, entryAssetPath);
+      this.buildDepAssets(entryAsset, entryAssetPath);
 
       this.bundle.childBundles.forEach(asset => {
         this.buildAssetDependecies(asset);
@@ -24,6 +24,7 @@ class DependencyGraph extends DepGraph {
     }
   }
 
+  // All files (assets) go trough this function
   buildAssetDependecies(asset) {
     const assetName = asset.name;
     const parentBundle = asset.parentBundle.name;
@@ -33,7 +34,7 @@ class DependencyGraph extends DepGraph {
     // React, Vue...
     // Handle imports from Javascript files
     if (isProjectJSCodeFile(assetName)) {
-      this.buildDependencyAssets(asset.entryAsset, assetName);
+      this.buildJSAssetDependecies(asset.entryAsset, assetName);
     }
 
     if (this.hasNode(parentBundle)) {
@@ -47,21 +48,41 @@ class DependencyGraph extends DepGraph {
     }
   }
 
-  buildDependencyAssets(asset, dependant) {
+  // Handles entry files imports (.depAssets property)
+  buildDepAssets(asset, dependant) {
     const dependencyAssets = Array.from(asset.depAssets);
 
-    dependencyAssets.forEach(dependency => {
-      dependency = dependency[1];
+    for (const dep of dependencyAssets) {
+      const dependency = dep[1];
       const dependencyName = dependency.parentBundle.name;
 
       this.addNode(dependencyName);
 
       if (dependencyName !== dependant) {
         this.addDependency(dependant, dependencyName);
-      } else {
-        this.buildDependencyAssets(dependency, dependant);
-      }
-    });
+      } /* else {
+        This can cause stack overflow, see #8
+        this.buildDepAssets(dependency, dependant);
+      } */
+    }
+  }
+
+  // Handles JS dist file imports only, but if needed, can be refactored
+  // to handle other dist file imports as well (.assets property)
+  buildJSAssetDependecies(asset, assetName) {
+    const assetType = asset.type;
+
+    // Dependency files (Raw Assets) of the <asset>
+    const depAssets = Array.from(asset.parentBundle.assets).filter(
+      depAsset => depAsset.type !== assetType
+    );
+
+    for (const depAsset of depAssets) {
+      const depAssetName = depAsset.parentBundle.name;
+
+      this.addNode(depAssetName);
+      this.addDependency(assetName, depAssetName);
+    }
   }
 
   getFilesByType(fileType) {

--- a/test/DependencyGraph.test.js
+++ b/test/DependencyGraph.test.js
@@ -1,9 +1,11 @@
 const path = require('path');
 const Bundler = require('parcel-bundler');
 const OutputCustomizer = require('../lib/index');
+const glob = require('glob');
 const DependencyGraph = require('../lib/DependencyGraph');
 
 let bundle;
+let depGraph;
 const CWD = process.cwd();
 
 describe('DependencyGraph', () => {
@@ -18,11 +20,11 @@ describe('DependencyGraph', () => {
     await OutputCustomizer(bundler);
 
     bundle = await bundler.bundle();
+    depGraph = new DependencyGraph(bundle);
     done();
   });
 
   it('tests that all files are present in dependency graph', () => {
-    const depGraph = new DependencyGraph(bundle);
     const entryAssetName = depGraph.bundle.name;
     const expectedEntryAssetName = path.join(CWD, 'dist', 'index.html');
 
@@ -32,5 +34,18 @@ describe('DependencyGraph', () => {
     const entryAssetDependecies = depGraph.dependenciesOf(entryAssetName);
 
     expect(nodes.length).toBe(entryAssetDependecies.length + 1);
+  });
+
+  it('tests that all dependecies are connected to their dependants accordingly', () => {
+    const outDir = path.join(CWD, 'dist');
+    const depGraphFiles = depGraph.outgoingEdges;
+
+    const jsFile = glob.sync(`${outDir}/js/*.js`)[0].replace('js/', '');
+    const cssFile = glob.sync(`${outDir}/css/*.css`)[0].replace('css/', '');
+    const entryFile = path.join(outDir, 'index.html');
+
+    expect(depGraphFiles[jsFile].length).toBe(2);
+    expect(depGraphFiles[cssFile].length).toBe(2);
+    expect(depGraphFiles[entryFile].length).toBe(4);
   });
 });


### PR DESCRIPTION
On bigger projects (800+ files) buildDependecyAssets() function would
cause plugin to crash. It would eat all memory because of it's recursive
design pattern.

I've refactored it in 2 separate functions:
1) buildDepAssets()
2) buildJSAssetDependecies()

The first one is for entry files imports and the second is for JS dist
file imports. This approach avoids stack overflow.

Minor Changes:
 - DependencyGraph test that tests if dependecies are connected properly
to their dependants

Resolves #8