### PR TITLE
FIX: Incorrect window file paths

### DIFF
--- a/lib/FileProcessor.js
+++ b/lib/FileProcessor.js
@@ -6,7 +6,8 @@ const {
   replaceInFileSync,
   isMapFile,
   getFileNameFromPath,
-  moveFileSync
+  moveFileSync,
+  toUnixPath
 } = require('./Utils');
 
 class FileProcessor {
@@ -64,8 +65,10 @@ class FileProcessor {
         absolute: true
       })[0];
 
-      const oldDepPath = `${publicURL}${path.relative(outDir, fileDepPath)}`;
-      let newDepPath = path.relative(folderPath, fileDepPath);
+      const oldDepPath = toUnixPath(
+        `${publicURL}${path.relative(outDir, fileDepPath)}`
+      );
+      let newDepPath = toUnixPath(path.relative(folderPath, fileDepPath));
 
       if (publicURL === '/') {
         // Remove ../ from the path
@@ -107,8 +110,10 @@ class FileProcessor {
       const fileDependantPath = this.depGraph.getNodeData(depPath);
       const oldFileName = getFileNameFromPath(oldFilePath);
 
-      const oldDependantPath = `${publicURL}${oldFileName}`;
-      const newDependantPath = `${publicURL}${folderName}/${oldFileName}`;
+      const oldDependantPath = toUnixPath(`${publicURL}${oldFileName}`);
+      const newDependantPath = toUnixPath(
+        `${publicURL}${folderName}/${oldFileName}`
+      );
 
       // Don't update the path in the entry file because it already contains a valid link
       if (

--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -14,9 +14,17 @@ exports.getPluginConfiguration = () => {
   return data.customDistStructure || {};
 };
 
-exports.getFileNameFromPath = (filePath, pathSeparator = path.sep) => {
-  return filePath.split(pathSeparator).slice(-1).join('');
+exports.getFileNameFromPath = filePath => {
+  if (filePath.includes('/')) {
+    // MacOS and Linux path
+    return filePath.split('/').slice(-1).join('');
+  }
+
+  // Windows path
+  return filePath.split('\\').slice(-1).join('');
 };
+
+exports.toUnixPath = filePath => filePath.replace(/\\/g, '/');
 
 exports.createFolderSync = folderPath => {
   fs.mkdirSync(folderPath, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-plugin-custom-dist-structure",
-  "version": "1.0.5",
+  "version": "1.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/Utils.test.js
+++ b/test/Utils.test.js
@@ -4,8 +4,8 @@ describe('Utils.js', () => {
   it('tests getFileNameFromPath()', () => {
     const { getFileNameFromPath } = Utils;
 
-    expect(getFileNameFromPath('/src/index.html', '/')).toBe('index.html');
-    expect(getFileNameFromPath('C:\\src\\index.html', '\\')).toBe('index.html');
+    expect(getFileNameFromPath('/src/index.html')).toBe('index.html');
+    expect(getFileNameFromPath('C:\\src\\index.html')).toBe('index.html');
   });
 
   it('tests isProjectJSCodeFile()', () => {


### PR DESCRIPTION
getFileNameFromPath() util function would file if the path delimiter is
not `path.sep`. The function can now extract the filename from any path
(Linux/Windows) without depending on `path.sep`.

toUnixPath() util function has been added to resolve paths on Windows.

Resolves #17