### PR TITLE
ADD: Custom absolute public-url functionality

### DIFF
--- a/lib/FileProcessor.js
+++ b/lib/FileProcessor.js
@@ -1,5 +1,5 @@
-const path = require('path');
 const fs = require('fs');
+const path = require('path');
 const glob = require('glob');
 const {
   createFolderSync,
@@ -70,7 +70,9 @@ class FileProcessor {
       );
       let newDepPath = toUnixPath(path.relative(folderPath, fileDepPath));
 
-      if (publicURL === '/') {
+      // If the publicURL is not "./", then it is the absolute url
+      // ("/" or custom absolute url like "/static/")
+      if (publicURL !== '') {
         // Remove ../ from the path
         newDepPath = newDepPath.replace(/\.\.\//g, '');
         newDepPath = `${publicURL}${newDepPath}`;


### PR DESCRIPTION
Recently, a developer working on a Django project has suggested an
option for custom absolute public-urls. In his case it is `/static/`
(Django).

Resolves #19