### PR TITLE
FIX: Incorrect file paths

### DIFF
--- a/lib/DependencyGraph.js
+++ b/lib/DependencyGraph.js
@@ -37,6 +37,11 @@ class DependencyGraph extends DepGraph {
       this.buildJSAssetDependecies(asset.entryAsset, assetName);
     }
 
+    // Html link to other html file (<a href="index.html">)
+    if (asset.type === 'html') {
+      this.buildDepAssets(asset.entryAsset, assetName);
+    }
+
     if (this.hasNode(parentBundle)) {
       this.addDependency(parentBundle, assetName);
     }

--- a/lib/FileProcessor.js
+++ b/lib/FileProcessor.js
@@ -57,13 +57,16 @@ class FileProcessor {
     if (!this.depGraph.hasNode(oldFilePath)) return;
     const fileDependeciesPaths = this.depGraph.dependenciesOf(oldFilePath);
 
-    fileDependeciesPaths.forEach(depPath => {
+    for (const depPath of fileDependeciesPaths) {
       // fileDepPath = this.depGraph.getNodeData(fileDepPath);
       let fileDepPath = getFileNameFromPath(depPath);
       fileDepPath = glob.sync(`**/*${fileDepPath}`, {
         cwd: outDir,
         absolute: true
       })[0];
+
+      // Sometimes on MacOS these result in undefined
+      if (!fileDepPath || !folderPath) continue;
 
       const oldDepPath = toUnixPath(
         `${publicURL}${path.relative(outDir, fileDepPath)}`
@@ -85,30 +88,35 @@ class FileProcessor {
           const fileContent = fs.readFileSync(newFilePath);
           // If we have a match, it means that we already have
           // a valid link and we shouldn't update it
-          if (fileContent.includes(newDepPath)) return;
+          if (fileContent.includes(newDepPath)) continue;
         }
+
+        const p = publicURL !== '' ? oldDepPath : newDepPath;
 
         replaceInFileSync(
           newFilePath,
           `${publicURL}${getFileNameFromPath(oldDepPath)}`,
-          newDepPath
+          p
         );
-        return;
+        continue;
       }
 
       replaceInFileSync(newFilePath, oldDepPath, newDepPath);
-    });
+    }
   }
 
   updateDependants() {
-    const { oldFilePath, folderName } = this;
     const { publicURL } = this.config;
+    const { oldFilePath, folderName } = this;
+
+    // Don't update dependants file links after the first run (development mode)
+    if (process.env.firstRun === 'false') return;
 
     // If the file that is not in the graph was provided (like .DS_Store)
     if (!this.depGraph.hasNode(oldFilePath)) return;
     const fileDependantsPaths = this.depGraph.dependantsOf(oldFilePath);
 
-    fileDependantsPaths.forEach(depPath => {
+    for (const depPath of fileDependantsPaths) {
       const fileDependantPath = this.depGraph.getNodeData(depPath);
       const oldFileName = getFileNameFromPath(oldFilePath);
 
@@ -117,26 +125,8 @@ class FileProcessor {
         `${publicURL}${folderName}/${oldFileName}`
       );
 
-      // Don't update the path in the entry file because it already contains a valid link
-      if (
-        process.env.firstRun === 'false' &&
-        this.depGraph.entryAssetPaths.includes(fileDependantPath)
-      ) {
-        return;
-      }
-
-      // When the map file is processed in the development mode (user specified ".map": "folder")
-      // It will wrongly update it's path in the dependant file (it collides)
-      // Example wrong path that we get -> i.e. ../maps/maps/style.2kj52.css.map
-      if (process.env.firstRun === 'false' && isMapFile(oldFilePath)) {
-        // if (!fs.existsSync(fileDependantPath)) return;
-        // const fileDependantContent = fs.readFileSync(fileDependantPath);
-        // if (fileDependantContent.includes(newDependantPath)) return;
-        return;
-      }
-
       replaceInFileSync(fileDependantPath, oldDependantPath, newDependantPath);
-    });
+    }
   }
 
   get newFilePath() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-plugin-custom-dist-structure",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Parcel plugin that allows you to specify a custom dist structure.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Having more than 1 level of nested folders inside of the `dist` folder
caused problems and links were wrong.

This change introduces a patch for this as well as a big refactor of
updateDependants() method and brings some performance improvements.
(forof > forEach)

Links from the entry HTML file to other HTML files referencing the same
stylesheet would cause incorrect paths from linked HTML files
to that stylesheet

v1.1.11

Resolves #22 #24