### PR TITLE
FIX #25: use alternative parcel bundler path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,12 @@
 const CWD = process.cwd();
 const path = require('path');
 const glob = require('glob');
+const fs = require('fs');
 
-const parcelDir = path.join(CWD, 'node_modules', 'parcel-bundler', 'src');
+let parcelDir = path.join(CWD, 'node_modules', 'parcel-bundler', 'src');
+if (!fs.existsSync(parcelDir))
+  parcelDir = path.join(CWD, 'node_modules', 'parcel', 'src');
+
 const HMRServerPath = glob.sync(path.join(parcelDir, '*HMRServer.js'))[0];
 
 const HMRServer = require(HMRServerPath);


### PR DESCRIPTION
if you installed parcel by the name `parcel` but not `parcel-bundler`, `parcelDir` will be not existed. This PR add extra checks to get the correct `parcelDir`.